### PR TITLE
allow user to define an absolute webroot where assets are hosted

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# gulp-css-useref 
+# gulp-css-useref
 
 [![NPM](https://nodei.co/npm/gulp-css-useref.png)](https://nodei.co/npm/gulp-useref/)
 
-> Parse CSS files to add assets referenced by `url()`s to the gulp file stream, and optionally transform their path. 
+> Parse CSS files to add assets referenced by `url()`s to the gulp file stream, and optionally transform their path.
 
 ## Install
 
@@ -15,7 +15,7 @@ npm install --save-dev gulp-css-useref
 
 ## Usage
 
-The following example will parse the CSS and pass the files referenced by `url()`s through. 
+The following example will parse the CSS and pass the files referenced by `url()`s through.
 
 ```js
 var gulp = require('gulp'),
@@ -51,23 +51,23 @@ Returns a stream with the assets referenced by `url()`s in any CSS files added.
 ## Options
 
 ### `match`
-Type: `string`  
+Type: `string`
 Default: `undefined`
 
-Optional [micromatch](https://github.com/jonschlinkert/micromatch "micromatch") style glob used to limit which assets are processed.  If the path specified in `url()` doesn't match this glob, it won't be processed.  
+Optional [micromatch](https://github.com/jonschlinkert/micromatch "micromatch") style glob used to limit which assets are processed.  If the path specified in `url()` doesn't match this glob, it won't be processed.
 
 ### `base`
-Type: `string`  
+Type: `string`
 Default: `''`
 
 Optional base path where the plugin will copy images, fonts, and other assets it finds in CSS `url()` declarations. Only `url()` declarations with relative paths are processed. Each asset's sub-directory hierarchy will be maintained under the base path. Basically, sub-directories after the last `../` in the path will be kept (or the whole path if no `../` exists). For example, if the plugin is called with `{ base: 'dist' }`, the image referred to by `url("../../images/icons/icon.jpg")` will be copied to `dist/images/icons/icon.jpg`.
 
 By using a single `base` path, a build pipeline can output several built CSS files while organizing all their assets under one directory (e.g. under `dist/` in `dist/images/`, `dist/fonts/`, etc.).
 
-If `base` is not specified, assets will be copied by default to the same directory relative to `gulp.dest` as the source asset from `gulp.src`, maintaining the assets' sub-directory hierarchy.  For example, if gulp is told to output to `dist` and `base` is not specified, the image referred to from `app/css/index.css` by `url("../../images/icons/icon.jpg")` (which resolves to `images/icons/icon.jpg`) will be copied to `dist/images/icons/icon.jpg`.  
+If `base` is not specified, assets will be copied by default to the same directory relative to `gulp.dest` as the source asset from `gulp.src`, maintaining the assets' sub-directory hierarchy.  For example, if gulp is told to output to `dist` and `base` is not specified, the image referred to from `app/css/index.css` by `url("../../images/icons/icon.jpg")` (which resolves to `images/icons/icon.jpg`) will be copied to `dist/images/icons/icon.jpg`.
 
 ### `pathTransform`
-Type: `function`  
+Type: `function`
 Default: `undefined`
 
 Optional function that returns a transformed filesystem path to an asset file. Useful for adding revision hashes to filenames for cachebusting (e.g. `image-a7f234e8d4.jpg`), or handling special cases. The function is expected to be of the form given below:
@@ -78,7 +78,7 @@ Optional function that returns a transformed filesystem path to an asset file. U
  * @param {string} newAssetFile - Relative path to which asset would be copied by default
  * @param {string} cssFilePathRel - Relative path to the CSS file that referenced the asset
  * @param {string} urlMatch - The contents of the url() in the CSS file
- * @param {object} options - The options hash passed into gulp-css-useref 
+ * @param {object} options - The options hash passed into gulp-css-useref
  * @returns {string} - Transformed Relative path to which asset will be copied
  */
 pathTransform: function(newAssetFile, cssFilePathRel, urlMatch, options) {
@@ -86,6 +86,12 @@ pathTransform: function(newAssetFile, cssFilePathRel, urlMatch, options) {
     return newAssetFile;
 }
 ```
+
+### `setWebroot`
+Type: `string`
+Default: `Undefined`
+
+Optional absolute path where static assets reside, if they are referenced with absolute paths in CSS starting with a `/`. Paths to assets in CSS are unchanged.
 
 ## Credits
 

--- a/generateDirs.js
+++ b/generateDirs.js
@@ -34,6 +34,17 @@ function generateDirs(cssFilePathRel, urlMatch, options) {
 	//   urlMatch         = '../../images/foo.png?a=123'
 	//   options.base     = 'assets'
 
+	if (options.setWebroot) {
+		var assetAbsolutePath = url.parse(options.setWebroot + urlMatch).pathname;
+		var newAssetRelPath = path.join(options.base, url.parse(urlMatch.substring(1)).pathname);
+
+		return {
+			newUrl: urlMatch,
+			assetPath: assetAbsolutePath,
+			newAssetFile: newAssetRelPath
+		};
+	}
+
 	// 'css\page'
 	var cssFromDirRel = path.dirname(cssFilePathRel);
 	// assetUrlParsed.pathname = '../../images/foo.png'

--- a/index.js
+++ b/index.js
@@ -65,8 +65,7 @@ function processUrlDecls(file, options) {
 			var urlMatch = trimUrlValue(urlMatch);
 
 			// Ignore absolute urls, data URIs, or hashes
-			if (urlMatch.indexOf('/') === 0 ||
-				urlMatch.indexOf('data:') === 0 ||
+			if (urlMatch.indexOf('data:') === 0 ||
 				urlMatch.indexOf('#') === 0 ||
 				/^[a-z]+:\/\//.test(urlMatch)) {
 				return fullMatch;
@@ -75,16 +74,26 @@ function processUrlDecls(file, options) {
 			if (options.match && !micromatch.isMatch(urlMatch, options.match))
 				return fullMatch;
 
-			var dirs = generateDirs(file.relative, urlMatch, options);
-			var newUrl = dirs.newUrl;
-			var assetPath = dirs.assetPath;
-			var newAssetFile = dirs.newAssetFile;
+			// Process absolute URLs if a webroot is set
+			var dirs, assetFromAbs;
 
-			var assetFromAbs = path.resolve(path.dirname(file.path), assetPath);
+			if (options.setWebroot) {
+				dirs = generateDirs("_", urlMatch, options)
+				assetFromAbs = dirs.assetPath;
+			}
+			else if (urlMatch.indexOf('/') === 0) {
+				return fullMatch;
+			}
+			else {
+				dirs = generateDirs(file.relative, urlMatch, options);
+				assetFromAbs = path.resolve(path.dirname(file.path), dirs.assetPath);
+			}
+
+			var newUrl = dirs.newUrl;
+			var newAssetFile = dirs.newAssetFile;
 
 			var cssBaseDirAbs = file.path.substr(0, file.path.length - file.relative.length);
 			var newAssetFileAbs = path.join(cssBaseDirAbs, newAssetFile);
-
 
 			var cssFromDirAbs = path.dirname(file.path);
 

--- a/test/fixtures/3/css/absoluterootasset.css
+++ b/test/fixtures/3/css/absoluterootasset.css
@@ -1,0 +1,7 @@
+@font-face {
+  font-family: 'FontAwesome';
+  src: url('/fonts/asset1.eot?v=4.5.0');
+  src: url('/fonts/asset1.woff2?v=4.5.0') format('woff2');
+  font-weight: normal;
+  font-style: normal;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -637,4 +637,25 @@ describe('gulp-use-css filter', function() {
 				cb();
 			}));
 	});
+
+	//
+	describe('with absolute assets from root', function() {
+		it('should handle assets from a user-defined webroot', function(done) {
+			var files = [];
+
+			gulp.src(path.normalize('test/fixtures/3/css/absoluterootasset.css'), { base: 'test/fixtures/3' })
+				.pipe(gulpUseCssUseRef({ setWebroot: path.resolve('test/fixtures/1') }))
+				.pipe(through.obj(function(file, enc, callback) {
+					files.push(file);
+					callback();
+				}, function(cb) {
+					expect(files).to.have.lengthOf(3);
+					expect(files).to.contain.something.that.has.property('relative', fixBackslashesInPath('fonts\\asset1.eot', path.sep));
+					expect(files).to.contain.something.that.has.property('relative', fixBackslashesInPath('fonts\\asset1.woff2', path.sep));
+					expect(files).to.contain.something.that.has.property('relative', fixBackslashesInPath('css\\absoluterootasset.css', path.sep));
+					done();
+					cb();
+				}));
+		});
+	});
 });


### PR DESCRIPTION
Hi, this PR adds a `setWebroot` option to the plug-in. I'm working on a project that references static assets absolutely from the webroot, like this: `url('images/picture.jpg')`. The CSS gets moved to a different host in production, and this enhancement makes it easier to find and publish images to that host along with the stylesheets by which they are referenced.