### PR TITLE
allow-dash-in-absolute-url-schema-filter

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ function processUrlDecls(file, options) {
 			if (urlMatch.indexOf('/') === 0 ||
 				urlMatch.indexOf('data:') === 0 ||
 				urlMatch.indexOf('#') === 0 ||
-				/^[a-z]+:\/\//.test(urlMatch)) {
+				/^[a-z-]+:\/\//.test(urlMatch)) {
 				return fullMatch;
 			}
 


### PR DESCRIPTION
Browser Extensions Api has implemented custom protocols e.g:
chrome-extension://
moz-extension://
ms-browser-extension://

This allows following schema in css urls:

'chrome-extension://__MSG_@@extension_id__/[path].[ext]'
'moz-extension://__MSG_@@extension_id__/[path].[ext]'
'ms-browser-extension://__MSG_@@extension_id__/[path].[ext]'

Files referenced by such schemas cannot be fetched thus should be treated same as other absolute urls.